### PR TITLE
Add a badge for specifying current stage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # RegExp Lookbehind Assertions
 
+![Stage 4](https://badges.aleen42.com/src/tc39_5.svg)
+
 Authors: Gorkem Yakin, Nozomu Katō, Daniel Ehrenberg
 
 Stage 4


### PR DESCRIPTION
According to https://es.discourse.group/t/a-standard-badge-for-tc39/731, automatically generate a badge for specifying current stage of the proposal.